### PR TITLE
Regular Expression parsing and refactoring of modules

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -3,7 +3,6 @@ version = "0.2.0"
 description = "A JavaScript parser written in Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "desertthunder", repo = "js_parser" }
-# links = [{ title = "Website", href = "" }]
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "js_parser"
-version = "0.2.0"
+version = "0.3.0"
 description = "A JavaScript parser written in Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "desertthunder", repo = "js_parser" }

--- a/samples/js/regex.js
+++ b/samples/js/regex.js
@@ -1,0 +1,7 @@
+export function regexTestCase(input) {
+    const notLiteral = new RegExp("ab + c");
+    const re = /error+here?/;
+
+    notLiteral.test("something")
+    re.test("something else")
+}

--- a/samples/js/regexExpanded.js
+++ b/samples/js/regexExpanded.js
@@ -1,0 +1,5 @@
+export function regexTestCase(input) {
+    const re = /^(?:\d{3}|\(\d{3}\))([-/.])\d{3}\1\d{4}$/;
+    const another = /lol/;
+    re.test(input)
+}

--- a/src/js_parser/predicates.gleam
+++ b/src/js_parser/predicates.gleam
@@ -8,7 +8,11 @@ pub fn is_letter(char: String) -> Bool {
 }
 
 pub fn is_identifier_char(char: String) -> Bool {
-  char == "_" || char == "$" || is_letter(char)
+  char == "_" || char == "$" || is_letter(char) || is_number(char)
+}
+
+fn is_number(char) {
+  ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"] |> list.contains(char)
 }
 
 pub fn is_punctuator_start(char: String) -> Bool {

--- a/test/js_parser_test.gleam
+++ b/test/js_parser_test.gleam
@@ -25,6 +25,42 @@ pub fn read_file_test() {
   }
 }
 
+pub fn parse_no_surrounding_whitespace_division_character_test() {
+  "let div = 4/4; "
+  |> js_parser.parse
+  |> should.equal([
+    js_parser.IdentifierName("let"),
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("div"),
+    js_parser.CharWhitespace(" "),
+    js_parser.Punctuator(js_parser.CharEquals),
+    js_parser.CharWhitespace(" "),
+    js_parser.NumericLiteral("4"),
+    js_parser.Punctuator(js_parser.CharBackslash),
+    js_parser.NumericLiteral("4"),
+    js_parser.CharSemicolon,
+  ])
+}
+
+pub fn parse_backslash_character_test() {
+  "let div = 4 / 2;"
+  |> js_parser.parse
+  |> should.equal([
+    js_parser.IdentifierName("let"),
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("div"),
+    js_parser.CharWhitespace(" "),
+    js_parser.Punctuator(js_parser.CharEquals),
+    js_parser.CharWhitespace(" "),
+    js_parser.NumericLiteral("4"),
+    js_parser.CharWhitespace(" "),
+    js_parser.Punctuator(js_parser.CharBackslash),
+    js_parser.CharWhitespace(" "),
+    js_parser.NumericLiteral("2"),
+    js_parser.CharSemicolon,
+  ])
+}
+
 pub fn regexp_test() {
   read_file("samples/js/regex.js")
   |> js_parser.parse

--- a/test/js_parser_test.gleam
+++ b/test/js_parser_test.gleam
@@ -25,6 +25,119 @@ pub fn read_file_test() {
   }
 }
 
+pub fn regexp_test() {
+  read_file("samples/js/regex.js")
+  |> js_parser.parse
+  |> should.equal([
+    js_parser.KeywordExport,
+    js_parser.CharWhitespace(" "),
+    js_parser.KeywordFunction,
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("regexTestCase"),
+    js_parser.CharOpenParen,
+    js_parser.IdentifierName("input"),
+    js_parser.CharCloseParen,
+    js_parser.CharWhitespace(" "),
+    js_parser.CharOpenBrace,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharWhitespace("    "),
+    js_parser.KeywordConst,
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("notLiteral"),
+    js_parser.CharWhitespace(" "),
+    js_parser.Punctuator(js_parser.CharEquals),
+    js_parser.CharWhitespace(" "),
+    js_parser.KeywordNew,
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("RegExp"),
+    js_parser.CharOpenParen,
+    js_parser.StringLiteral("ab + c", True),
+    js_parser.CharCloseParen,
+    js_parser.CharSemicolon,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharWhitespace("    "),
+    js_parser.KeywordConst,
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("re"),
+    js_parser.CharWhitespace(" "),
+    js_parser.Punctuator(js_parser.CharEquals),
+    js_parser.CharWhitespace(" "),
+    js_parser.RegularExpressionLiteral("error+here?", True),
+    js_parser.CharSemicolon,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharWhitespace("    "),
+    js_parser.IdentifierName("notLiteral"),
+    js_parser.CharDot,
+    js_parser.IdentifierName("test"),
+    js_parser.CharOpenParen,
+    js_parser.StringLiteral("something", True),
+    js_parser.CharCloseParen,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharWhitespace("    "),
+    js_parser.IdentifierName("re"),
+    js_parser.CharDot,
+    js_parser.IdentifierName("test"),
+    js_parser.CharOpenParen,
+    js_parser.StringLiteral("something else", True),
+    js_parser.CharCloseParen,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharCloseBrace,
+    js_parser.LineTerminatorSequence("\n"),
+  ])
+}
+
+pub fn regexp_expanded_test() {
+  read_file("samples/js/regexExpanded.js")
+  |> js_parser.parse
+  |> should.equal([
+    js_parser.KeywordExport,
+    js_parser.CharWhitespace(" "),
+    js_parser.KeywordFunction,
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("regexTestCase"),
+    js_parser.CharOpenParen,
+    js_parser.IdentifierName("input"),
+    js_parser.CharCloseParen,
+    js_parser.CharWhitespace(" "),
+    js_parser.CharOpenBrace,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharWhitespace("    "),
+    js_parser.KeywordConst,
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("re"),
+    js_parser.CharWhitespace(" "),
+    js_parser.Punctuator(js_parser.CharEquals),
+    js_parser.CharWhitespace(" "),
+    js_parser.RegularExpressionLiteral(
+      "^(?:d{3}|(d{3}))([-/.])d{3}1d{4}$",
+      True,
+    ),
+    js_parser.CharSemicolon,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharWhitespace("    "),
+    js_parser.KeywordConst,
+    js_parser.CharWhitespace(" "),
+    js_parser.IdentifierName("another"),
+    js_parser.CharWhitespace(" "),
+    js_parser.Punctuator(js_parser.CharEquals),
+    js_parser.CharWhitespace(" "),
+    js_parser.RegularExpressionLiteral("lol", True),
+    js_parser.CharSemicolon,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharWhitespace("    "),
+    js_parser.IdentifierName("re"),
+    js_parser.CharDot,
+    js_parser.IdentifierName("test"),
+    js_parser.CharOpenParen,
+    js_parser.IdentifierName("input"),
+    js_parser.CharCloseParen,
+    js_parser.LineTerminatorSequence("\n"),
+    js_parser.CharCloseBrace,
+    js_parser.LineTerminatorSequence("\n"),
+  ])
+}
+
 pub fn parse_string_variable_assignment_test() {
   "let some_var = 'value'"
   |> js_parser.parse
@@ -237,11 +350,25 @@ pub fn double_quote_string_literal_test() {
   |> should.equal([js_parser.StringLiteral("ok", True)])
 }
 
+pub fn unterminated_double_quote_string_literal_test() {
+  let input = "\"ok"
+  input
+  |> js_parser.parse
+  |> should.equal([js_parser.StringLiteral("ok", False)])
+}
+
 pub fn single_quote_string_literal_test() {
   let input = "'ok'"
   input
   |> js_parser.parse
   |> should.equal([js_parser.StringLiteral("ok", True)])
+}
+
+pub fn parse_unterminated_single_quote_string_literal_test() {
+  let input = "'ok"
+  input
+  |> js_parser.parse
+  |> should.equal([js_parser.StringLiteral("ok", False)])
 }
 
 pub fn parse_string_literal_with_escape_char_test() {


### PR DESCRIPTION
This PR adds regular expression support to the tokenizer.

It does so by handling `/` characters, requiring distinguishing between the division operator and the start of a regex literal.